### PR TITLE
Consolidate output to a per-package files.

### DIFF
--- a/cmd/ego/main.go
+++ b/cmd/ego/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"go/scanner"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -11,11 +12,9 @@ import (
 	"github.com/benbjohnson/ego"
 )
 
-func init() {
-	log.SetFlags(0)
-}
-
 func main() {
+	log.SetFlags(0)
+
 	// Parse the command line flags.
 	flag.Parse()
 	if flag.NArg() == 0 {
@@ -24,7 +23,7 @@ func main() {
 
 	// Loop over each path and generate all ego templates within it.
 	for _, path := range flag.Args() {
-		if err := filepath.Walk(path, walk); err != nil {
+		if err := filepath.Walk(path, visit); err != nil {
 			scanner.PrintError(os.Stderr, err)
 			os.Exit(1)
 		}
@@ -36,30 +35,52 @@ func usage() {
 	os.Exit(1)
 }
 
-func walk(path string, info os.FileInfo, err error) error {
-	// Only ego file are used for generation.
+func visit(path string, info os.FileInfo, err error) error {
 	if info == nil {
 		return fmt.Errorf("file not found: %s", path)
-	} else if info.IsDir() || filepath.Ext(path) != ".ego" {
-		return nil
+	} else if info.IsDir() {
+		return visitDir(path)
 	}
+	return nil
+}
 
-	// Parse ego file into a template.
-	t, err := ego.ParseFile(path)
+func visitDir(path string) error {
+	// List all files in the directory.
+	infos, err := ioutil.ReadDir(path)
 	if err != nil {
 		return err
 	}
 
-	// Write template to output file.
-	filename := fmt.Sprintf("%s.go", path)
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode())
+	// Parse every *.ego file.
+	var templates []*ego.Template
+	for _, info := range infos {
+		if info.IsDir() || filepath.Ext(info.Name()) != ".ego" {
+			continue
+		}
+
+		// Parse ego file into a template.
+		t, err := ego.ParseFile(filepath.Join(path, info.Name()))
+		if err != nil {
+			return err
+		}
+		templates = append(templates, t)
+	}
+
+	// If we have no templates then exit.
+	if len(templates) == 0 {
+		return nil
+	}
+
+	// Write package to output file.
+	p := &ego.Package{Templates: templates, Name: filepath.Base(path)}
+	f, err := os.Create(filepath.Join(path, "ego.go"))
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
 	// Write template to file.
-	if err := t.WriteFormatted(f); err != nil {
+	if err := p.WriteFormatted(f); err != nil {
 		return err
 	}
 

--- a/template_test.go
+++ b/template_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Ensure that a template can be written to a writer.
-func TestTemplateWrite(t *testing.T) {
+func TestTemplate_Write(t *testing.T) {
 	var buf bytes.Buffer
 	tmpl := &Template{
 		Blocks: []Block{


### PR DESCRIPTION
## Overview

Previously, ego would generate a single `.ego.go` file for every `.ego` template that it found. This makes for a lot of output files. This commit changes the functionality so that ego generates a single `ego.go` file per package.

Source map line pragmas (e.g. `//line orig.ego:10`) still exist so errors will still be mapped correctly.
## Caveats
- Imports are now parsed from each `<%% ... %%>` block and consolidated into a single import block. This means that different imports with the same name are not allowed. Although, that's just a bad idea anyway.
- Packages are required to be named the same as the folder name they're in. You can no longer specify a package name in your `<%% ... %%>` blocks. This is the recommended Go style so I don't think this is a problem.

---

/cc @boourns
