### PR TITLE
Allow subfolders in preprocessor line directives.

### DIFF
--- a/template.go
+++ b/template.go
@@ -9,7 +9,6 @@ import (
 	"go/token"
 	"io"
 	"os"
-	"path/filepath"
 )
 
 // Template represents an entire Ego template.
@@ -178,7 +177,7 @@ type Pos struct {
 
 func (p *Pos) write(buf *bytes.Buffer) {
 	if p != nil && p.Path != "" && p.LineNo > 0 {
-		fmt.Fprintf(buf, "//line %s:%d\n", filepath.Base(p.Path), p.LineNo)
+		fmt.Fprintf(buf, "//line %s:%d\n", p.Path, p.LineNo)
 	}
 }
 


### PR DESCRIPTION
When organizing templates in folders the path in the preprocessor lines where not matching the real path.