### PR TITLE
fix % signs in TextBlock

### DIFF
--- a/template.go
+++ b/template.go
@@ -124,7 +124,7 @@ type TextBlock struct {
 
 func (b *TextBlock) write(buf *bytes.Buffer) error {
 	b.Pos.write(buf)
-	fmt.Fprintf(buf, `_, _ = fmt.Fprintf(w, %q)`+"\n", b.Content)
+	fmt.Fprintf(buf, `_, _ = fmt.Fprint(w, %q)`+"\n", b.Content)
 	return nil
 }
 


### PR DESCRIPTION
Using Fprint instead of Fprintf allows using of `%` signs in plain text (e.g. in embedded stylesheets).

Otherwise plain text `Hello % sign` would be printed as `Hello %!s(MISSING)ign`