### PR TITLE
Add support for HTML escaped string outputting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ An ego template is made up of several types of blocks:
 
 * **Code Block** - These blocks execute raw Go code: `<% var foo = "bar" %>`
 
-* **Print Block** - These blocks print a Go expression: `<%= myVar %>`
+* **Print Block** - These blocks print a Go expression. They use `html.EscapeString` to escape it before outputting: `<%= myVar %>`
+
+* **Raw Print Block** - These blocks print a Go expression raw into the HTML: `<%== "<script>" %>`
 
 * **Header Block** - These blocks allow you to import packages: `<%% import "encoding/json" %%>`
 

--- a/template_test.go
+++ b/template_test.go
@@ -20,7 +20,7 @@ func TestTemplate_Write(t *testing.T) {
 			&DeclarationBlock{Content: " func MyTemplate(w io.Writer, nums []int) error "},
 			&CodeBlock{Content: "  for _, num := range nums {"},
 			&TextBlock{Content: "    <p>"},
-			&PrintBlock{Content: "num + 1"},
+			&RawPrintBlock{Content: "num + 1"},
 			&TextBlock{Content: "    </p>"},
 			&CodeBlock{Content: "  }"},
 			&TextBlock{Content: "</html>"},


### PR DESCRIPTION
This adds support for the `<%-` block which does HTML escaping for you. I chose `<%-` because that's what lodash uses, and I'd also prefer not to break backwards compat

@benbjohnson 

Fixes #4 