### PR TITLE
use WriteString instead of Fprint for "go vet" reasons

### DIFF
--- a/template.go
+++ b/template.go
@@ -298,7 +298,7 @@ func (p *Package) writeHeader(w io.Writer) error {
 	}
 	fmt.Fprint(&buf, ")\n")
 
-	fmt.Fprint(&buf, `var compatibility = fmt.Sprint("") // just so that we can keep the fmt import for now`+"\n")
+	fmt.Fprint(&buf, `var _ = fmt.Sprint("") // just so that we can keep the fmt import for now`+"\n")
 
 	// Write out to writer.
 	buf.WriteTo(w)

--- a/template.go
+++ b/template.go
@@ -133,7 +133,7 @@ type TextBlock struct {
 
 func (b *TextBlock) write(buf *bytes.Buffer) error {
 	b.Pos.write(buf)
-	fmt.Fprintf(buf, `_, _ = fmt.Fprint(w, %q)`+"\n", b.Content)
+	fmt.Fprintf(buf, `_, _ = io.WriteString(w, %q)`+"\n", b.Content)
 	return nil
 }
 
@@ -187,7 +187,7 @@ type PrintBlock struct {
 
 func (b *PrintBlock) write(buf *bytes.Buffer) error {
 	b.Pos.write(buf)
-	fmt.Fprintf(buf, `_, _ = fmt.Fprint(w, html.EscapeString(fmt.Sprintf("%%v", %s)))`+"\n", b.Content)
+	fmt.Fprintf(buf, `_, _ = io.WriteString(w, html.EscapeString(fmt.Sprintf("%%v", %s)))`+"\n", b.Content)
 	return nil
 }
 
@@ -297,6 +297,8 @@ func (p *Package) writeHeader(w io.Writer) error {
 		}
 	}
 	fmt.Fprint(&buf, ")\n")
+
+	fmt.Fprint(&buf, `var compatibility = fmt.Sprint("") // just so that we can keep the fmt import for now`+"\n")
 
 	// Write out to writer.
 	buf.WriteTo(w)


### PR DESCRIPTION
The current implementation `fmt.Fprint` causes `go vet` issues ("possible formatting directive in Fprint call") if templates contain `%` signs (e.g. for css). See https://gist.github.com/tobstarr/fa73f87cb1953ca01e8a for an example.

Instead one could just use `io.WriteString`, which is also quite a bit faster (see benchmark in gist).